### PR TITLE
docs(p0): Inngest audit and keep/change matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ next-env.d.ts
 
 # Ignore all markdown files
 *.md
+# Track task/audit docs
+!tasks/*.md
 
 # Ignore specific files
 prd.json

--- a/tasks/p0-inngest-audit.md
+++ b/tasks/p0-inngest-audit.md
@@ -1,0 +1,160 @@
+# P0 Inngest Audit and Keep/Change Matrix
+
+## 1. Overview
+This audit documents the current Inngest-triggered build flow in Lambda, covering both `inngest.send` trigger callsites, the `code-agent/run` worker implementation, all known database side effects, and the main durability, correctness, and architecture risks relevant to the Router→Worker migration described in initiative #19. The goal is to capture what should be preserved, what should be changed, and where the current system creates operational or product risk.
+
+## 2. Trigger Inventory
+| Callsite | File:Line | Procedure Tier | Pre-dispatch DB Writes | Event Name | Payload Shape | Error Handling |
+|---|---|---|---|---|---|---|
+| Project creation flow | `src/modules/projects/server/procedures.ts:76` | `usageProtectedProcedure` | `prisma.project.create` with nested `Message` (`role=USER`, `type=RESULT`) | `code-agent/run` | `{ value: string, projectId: string }` | On `inngest.send` failure, deletes created project via `prisma.project.delete({ where: { id: createdProject.id } })` |
+| Follow-up message flow | `src/modules/messages/server/procedures.ts:70` | `usageProtectedProcedure` | Ownership check, then `prisma.message.create` (`role=USER`, `type=RESULT`) | `code-agent/run` | `{ value: string, projectId: string }` | No rollback on `inngest.send` failure; USER message remains persisted |
+
+## 3. Worker Step Breakdown
+| Step Name | What It Does | External Call | DB Read/Write | Durable (`step.run`)? | Notes |
+|---|---|---|---|---|---|
+| `get-sandbox-id` | Creates a sandbox for the run and returns `sandboxId` | `Sandbox.create("lambda")`, sets `SANDBOX_TIMEOUT` | None | Yes | First durable step; sandbox lifecycle begins here |
+| `get-previous-messages` | Loads last 5 messages for the project, reverses them, formats as `Message[]` | None beyond Prisma client | Read: `prisma.message.findMany({ where: { projectId }, orderBy: { createdAt: "desc" }, take: 5 })` | Yes | Hardcoded 5-message limit; worker context rebuilt from DB rather than event payload |
+| `createState<AgentState>` | Initializes agent state with empty summary and files plus prior messages | None | None | No | Pure in-memory setup before network execution |
+| `createNetwork` / `codeAgent` | Runs the main AgentKit network with `gpt-5-mini`, `maxIter: 15` | LLM call to `codeAgent` | None directly | No | Router stops when `summary` is set; otherwise continues to `codeAgent` |
+| `terminal` tool | Runs terminal commands inside sandbox | `sandbox.commands.run(command)` | None | Yes | Wrapped via `step.run("terminal")`; sandbox side effects occur outside DB |
+| `createOrUpdateFiles` tool | Writes one or more files into sandbox and updates in-memory `files` map | `sandbox.files.write` repeated `N` times | None | Yes | Durable wrapper, but resulting file map lives in network state until `save-result` |
+| `readFiles` tool | Reads files from sandbox | `sandbox.files.read` repeated `N` times | None | Yes | Durable wrapper for file reads |
+| `onResponse` lifecycle | Captures `<task_summary>` output and writes summary into network state | LLM response hook | None | No | Sentinel-driven parsing is fragile; governs router termination |
+| `fragmentTitleGenerator.run(...)` | Generates fragment title from summary using `gpt-5-mini` | LLM call | None | No | Not wrapped in `step.run`; re-executes on retry |
+| `responseGenerator.run(...)` | Generates user-facing response from summary using `gpt-5-mini` | LLM call | None | No | Not wrapped in `step.run`; re-executes on retry |
+| `get-sandbox-url` | Resolves public sandbox URL | `sandbox.getHost(3000)` and formats `https://${host}` | None | Yes | Assumes app exposed on port `3000` |
+| `save-result` | Persists either error message or successful assistant result with fragment | Prisma writes | Write: `prisma.message.create(...)`; on success also nested `fragment.create` | Yes | `isError = !summary || Object.keys(files).length === 0`; no dedupe/idempotency guard |
+
+## 4. DB Side Effects
+| Model | Operation | When | Owned By | Rollback Exists? |
+|---|---|---|---|---|
+| `Project` | `create` | Triggered by project creation flow before dispatch | `projects.create` trigger | Yes, if `inngest.send` fails |
+| `Message` | Nested `create` (`role=USER`, `type=RESULT`) | Alongside project creation before dispatch | `projects.create` trigger | Yes, indirectly via project deletion |
+| `Message` | `create` (`role=USER`, `type=RESULT`) | Triggered by follow-up message flow before dispatch | `messages.create` trigger | No |
+| `Message` | `findMany` (last 5) | Worker context load before network run | `get-previous-messages` worker step | Not applicable |
+| `Message` | `create` (`role=ASSISTANT`, `type=ERROR`) | `save-result` when `summary` missing or `files` empty | `save-result` worker step | No |
+| `Message` | `create` (`role=ASSISTANT`, `type=RESULT`) | `save-result` when `summary` present and files non-empty | `save-result` worker step | No |
+| `Fragment` | Nested `create` with `sandboxUrl`, `title`, `files` | On successful `save-result` | `save-result` worker step | No |
+
+## 5. Keep / Change Matrix
+| Component | Decision | Rationale |
+|---|---|---|
+| E2B sandbox creation | Keep with changes | Sandbox-per-run is aligned with build isolation, but lifecycle metadata should move onto an explicit run record and be tied to durable orchestration semantics |
+| `terminal` tool | Keep | Executing commands in the sandbox is core to build execution and should remain part of the worker surface |
+| `createOrUpdateFiles` tool | Keep | Writing generated files is a necessary build capability and maps directly to artifact creation |
+| `readFiles` tool | Keep | Reading sandbox files is required for agent iteration and verification |
+| AgentKit network (`gpt-5-mini`) | Change | The agent loop is useful, but it should be reframed behind Router→Worker boundaries with explicit run state, stronger completion signals, and better retry/idempotency guarantees |
+| `<task_summary>` sentinel pattern | Change | Parsing raw model output for a sentinel is brittle and can fail silently or produce false positives; completion should use structured state or explicit tool/result channels |
+| `fragmentTitleGenerator` | Change | Post-network title generation is reasonable, but it must be made durable or folded into a deterministic post-processing stage to avoid retry drift |
+| `responseGenerator` | Change | Same issue as title generation; current non-durable execution can re-run inconsistently on retry |
+| `get-previous-messages` (5-msg limit) | Change | Rehydrating only five messages is a hardcoded context cap that may truncate important state; target architecture should use explicit router state or configurable history selection |
+| Event name `code-agent/run` | Change | A single event name hides whether the run came from new-project creation or follow-up continuation, which complicates routing, analytics, and evolution toward Chat/Build modes |
+| Event payload shape | Change | Payload lacks `messageId`, run identity, trigger type, and mode; worker must re-query context indirectly instead of consuming explicit input references |
+| `save-result` DB write | Keep with changes | Persisting an assistant result is correct, but it needs idempotency protection and probably should attach to a first-class run/artifact record |
+| `projects.create` rollback | Keep | Rolling back pre-dispatch writes on failed dispatch is correct and should be preserved |
+| `messages.create` (no rollback) | Change | Persisting orphaned USER messages on dispatch failure creates inconsistent history and should be replaced with rollback or deferred commit semantics |
+| `usageProtectedProcedure` gating | Keep | Usage-based access control/gating belongs at the trigger boundary and should remain in place |
+| Step durability pattern | Keep with changes | Durable `step.run` boundaries are the right mechanism, but they are currently applied inconsistently across the workflow |
+| Post-network agents (non-durable) | Change | Any model-driven post-processing that affects persisted output must be moved under durable steps or made deterministic |
+
+## 6. Sequence Diagrams (Mermaid)
+
+### Diagram A - Current Flow
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant T as tRPC Procedure
+    participant DB as Prisma / DB
+    participant I as Inngest
+    participant W as codeAgentFunction Worker
+    participant S as E2B Sandbox
+    participant L as LLM / AgentKit
+
+    U->>T: Create project or send follow-up message
+    alt projects.create
+        T->>DB: create Project + nested USER Message
+        T->>I: inngest.send("code-agent/run", { value, projectId })
+        alt send fails
+            T->>DB: delete Project
+        end
+    else messages.create
+        T->>DB: create USER Message
+        T->>I: inngest.send("code-agent/run", { value, projectId })
+        alt send fails
+            Note over T,DB: No rollback; USER message persists
+        end
+    end
+
+    I->>W: Trigger code-agent/run
+    W->>S: step.run("get-sandbox-id") / Sandbox.create("lambda")
+    W->>DB: step.run("get-previous-messages") / findMany(last 5)
+    W->>L: createNetwork(codeAgent, gpt-5-mini, maxIter 15)
+    loop Agent iteration
+        L->>W: terminal / createOrUpdateFiles / readFiles
+        alt terminal
+            W->>S: step.run("terminal") / commands.run(...)
+        else createOrUpdateFiles
+            W->>S: step.run("createOrUpdateFiles") / files.write(...)
+        else readFiles
+            W->>S: step.run("readFiles") / files.read(...)
+        end
+        L->>W: raw output containing optional <task_summary>
+    end
+
+    W->>L: fragmentTitleGenerator.run(summary)
+    W->>L: responseGenerator.run(summary)
+    W->>S: step.run("get-sandbox-url") / getHost(3000)
+    alt summary missing or files empty
+        W->>DB: step.run("save-result") / create ASSISTANT ERROR message
+    else success
+        W->>DB: step.run("save-result") / create ASSISTANT RESULT + Fragment
+    end
+```
+
+### Diagram B - Target Router-Worker Flow
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as tRPC Router
+    participant DB as Prisma / DB
+    participant G as Confirmation Gate
+    participant I as Inngest
+    participant W as Build Worker
+    participant S as Sandbox
+    participant A as Artifact Version
+
+    U->>R: Submit input
+    alt Chat path
+        R->>DB: persist chat turn / router state
+        R-->>U: Chat response (no build dispatch)
+    else Build-intent path
+        R->>G: Require explicit confirmation / mode selection
+        G-->>R: Build approved
+        R->>DB: create Run record + input references + mode
+        R->>I: dispatch build event with runId, projectId, messageId, mode
+        I->>W: Start worker for run
+        W->>DB: load run + referenced context
+        W->>S: create sandbox
+        W->>W: execute durable build steps
+        W->>A: create artifact version from output files
+        W->>DB: persist run result + artifact linkage
+        W-->>U: Build result available via run/artifact records
+    end
+```
+
+## 7. Gap and Risk Register
+- `P0` No rollback in `messages.create` when `inngest.send` fails. Mitigation: wrap pre-dispatch message persistence in rollback logic or defer durable write until dispatch succeeds.
+- `P0` `fragmentTitleGenerator.run` and `responseGenerator.run` are not wrapped in `step.run`, so retries can regenerate different outputs. Mitigation: move both into durable steps or compute them deterministically from persisted state.
+- `P0` No deduplication/idempotency guard around `save-result`, so retries can create duplicate assistant messages. Mitigation: introduce a run record with unique constraint or idempotency key and make final write upsert-like.
+- `P1` Event payload lacks `messageId`, trigger type, mode, and run identity. Mitigation: expand payload to include explicit references and routing metadata.
+- `P1` Worker reconstructs context from DB using a hardcoded 5-message history window. Mitigation: replace with explicit router-selected context or configurable history policy.
+- `P1` `<task_summary>` sentinel in raw model output is fragile and can break completion detection. Mitigation: use structured outputs, explicit tool returns, or dedicated state mutation channels.
+- `P1` Single event name `code-agent/run` covers both new-project and follow-up flows, preventing branch-specific behavior and observability. Mitigation: split event types or include a required trigger discriminator.
+- `P2` Success is inferred from `summary` presence and non-empty `files`, which may not fully capture build correctness. Mitigation: introduce explicit run status and artifact validation criteria.
+- `P2` Sandbox URL generation assumes port `3000` and immediate host availability. Mitigation: store declared service port in run metadata or validate exposed app state before persisting success.
+
+## 8. Acceptance Checklist
+- [x] Every `inngest.send` callsite documented
+- [x] Every DB side effect of worker documented
+- [x] Keep/Change matrix complete
+- [x] Sequence diagrams cover current and target flows

--- a/tasks/phase1-delivery-master-plan.md
+++ b/tasks/phase1-delivery-master-plan.md
@@ -1,0 +1,652 @@
+# Phase 1 Delivery Master Plan
+
+Date: April 23, 2026  
+Source Inputs: discovery findings + initial product/routing/architecture answers
+
+## 1. Purpose
+This document is the master execution plan for migrating Lambda from generation-first behavior to a chat-first assistant with explicit `Chat` and `Build` modes, safe routing, confirmation-gated expensive workflows, async tool runs, and artifact-first persistence.
+
+It is written so each ticket can be delegated to a sub-agent independently.
+
+## 2. Product Requirements Checklist (Must All Be Satisfied)
+- Chat-first primary experience.
+- Explicit modes (`Chat`, `Build`).
+- Auto-detection + explicit user override.
+- Tool execution visibility via status carousel.
+- Chat is not source of truth for generated outputs.
+- Dedicated run/task model with lifecycle tracking.
+- Immutable artifact versions per run.
+- Clarifying questions before tool execution when needed.
+- Hard rule: never auto-run expensive workflows without explicit confirmation.
+- Sync chat path for fast first token + streaming depth.
+- Async tools via Inngest.
+- Router -> Worker architecture.
+- Thread-level memory in Phase 1.
+- Failed run UX with error summary + retry.
+- In-place migration acceptable.
+- Split budget policy (generous chat, strict tools).
+- Observability for routing decisions, success/failure rates, per-step latency.
+
+## 3. Architecture Target
+```text
+User Input
+  -> Router (rule-first + constrained model adjudication)
+      -> Chat Path (sync)
+      -> Build Path (requires confirmation)
+           -> Run Created
+           -> Inngest Worker (async)
+                -> Artifact Version + Files (source of truth)
+                -> Assistant response references artifact
+```
+
+## 3a. P0-1 Status (Issue #20)
+
+| Deliverable | Status |
+|-------------|--------|
+| `tasks/p0-inngest-audit.md` | ✅ Done |
+| Trigger inventory (2 callsites) | ✅ Done |
+| Worker step breakdown (12 steps) | ✅ Done |
+| DB side-effect table | ✅ Done |
+| Keep/Change matrix (16 rows) | ✅ Done |
+| Current-flow sequence diagram (Mermaid) | ✅ Done |
+| Target router-worker sequence diagram (Mermaid) | ✅ Done |
+| Gap/risk register (9 items, P0/P1/P2 severity) | ✅ Done |
+
+---
+
+## 4. Delivery Phases
+- Phase 0: Discovery lock + baseline metrics.
+- Phase 1: Routing foundation + mode contracts + confirmation gates.
+- Phase 2: Split execution paths (sync chat, async build).
+- Phase 3: Data model separation (messages vs runs vs artifacts).
+- Phase 4: Memory/context compression (thread-level only).
+- Phase 5: Observability, budget controls, rollout safety.
+
+---
+
+## Phase 0: Discovery Lock + Baseline
+
+### Ticket P0-1: Current-System Inngest Audit and Keep/Change Matrix
+**Outcome**: Unambiguous map of what remains unchanged vs must be adapted.
+
+**Why this exists**
+- Requirement explicitly states this analysis is the first step.
+- Prevents unnecessary rewrites of stable worker components.
+
+**Scope**
+- Audit all trigger points into Inngest.
+- Audit all data writes performed by current worker.
+- Document coupling between message creation and worker dispatch.
+
+**Implementation Tasks**
+1. Inventory current triggering paths:
+   - `projects.create`
+   - `messages.create`
+2. Inventory worker responsibilities in `src/inngest/functions.ts`.
+3. Map all persistent side effects:
+   - message creation
+   - fragment creation
+   - sandbox URL generation
+4. Build keep/change matrix with rationale:
+   - Keep: worker execution environment, tool interfaces where possible.
+   - Adapt: event payload, status tracking, output persistence model.
+   - Replace: implicit “every message triggers build.”
+5. Create sequence diagrams:
+   - Current flow.
+   - Target router-worker flow.
+
+**Deliverables**
+- `tasks/p0-inngest-audit.md`
+- Keep/change matrix table.
+- Current vs target sequence diagrams.
+
+**Dependencies**: none
+
+**Acceptance Criteria**
+- Every worker entry point is documented.
+- Every DB side effect of worker is documented.
+- Keep/change matrix signed off for next phase.
+
+**Validation**
+- Manual architecture review with checklist.
+
+**Risks**
+- Missing hidden entry points.
+
+**Mitigation**
+- Grep for `inngest.send` and event names, then verify route registration.
+
+---
+
+### Ticket P0-2: Baseline Metrics and Routing Risk Benchmark
+**Outcome**: Baseline to compare post-refactor improvements.
+
+**Why this exists**
+- Success requires proving reduced false positives and better responsiveness.
+
+**Scope**
+- Capture baseline latency and run behavior before code changes.
+
+**Implementation Tasks**
+1. Instrument current chat submit path timing.
+2. Instrument worker start/end and result state.
+3. Record event frequency: messages vs builds.
+4. Capture fail/success rate over representative local/staging runs.
+5. Save benchmark report.
+
+**Deliverables**
+- `tasks/p0-baseline-metrics.md` with p50/p95 timings and failure rates.
+
+**Dependencies**: P0-1
+
+**Acceptance Criteria**
+- Baseline includes:
+  - First response latency.
+  - Build completion latency.
+  - Build trigger frequency.
+  - Error rate.
+- Report can be compared against post-phase metrics.
+
+**Validation**
+- Reproducible script/steps documented.
+
+---
+
+## Phase 1: Routing Foundation
+
+### Ticket P1-1: Mode-Aware Input/Output Contracts (`Chat` vs `Build`)
+**Outcome**: API contracts support explicit modes and routing metadata.
+
+**Scope**
+- Extend message/project submit contracts and response payloads.
+
+**Implementation Tasks**
+1. Add input fields:
+   - `mode` (optional explicit override)
+   - `draftForExecution` (optional)
+2. Add routing metadata in response:
+   - `decision`
+   - `decisionSource` (`auto` or `explicit`)
+   - `confidence`
+   - `requiresConfirmation`
+3. Maintain backwards compatibility:
+   - If `mode` omitted, default to auto routing.
+4. Add types shared across client + server.
+
+**Deliverables**
+- Updated router input/output schemas.
+- Shared type definitions.
+
+**Dependencies**: P0-1
+
+**Acceptance Criteria**
+- Explicit mode can be sent from UI.
+- Legacy clients still work when `mode` absent.
+- API returns routing metadata for observability/UI.
+
+**Validation**
+- Unit tests for schema parsing and fallback defaults.
+
+---
+
+### Ticket P1-2: Rule-First Router with Constrained Model Adjudication
+**Outcome**: Deterministic routing that minimizes false-positive build execution.
+
+**Scope**
+- Build router module used by submit flows.
+
+**Implementation Tasks**
+1. Implement rule-first checks:
+   - Explicit build intent -> build candidate.
+   - Explicit chat intent -> chat.
+2. Implement high-confidence structured intent detection.
+3. Default ambiguous cases to chat.
+4. Optional model adjudication only in ambiguous middle band.
+5. Enforce hard policy: expensive workflows cannot auto-execute without confirmation.
+6. Emit routing decision logs with reason and confidence.
+
+**Deliverables**
+- Routing service module.
+- Router decision schema.
+- Configurable thresholds.
+
+**Dependencies**: P1-1
+
+**Acceptance Criteria**
+- No auto execution of expensive build without confirm flag.
+- Ambiguous prompts route to chat.
+- Routing logs include reason/confidence/source.
+
+**Validation**
+- Test matrix of prompts:
+  - explicit build
+  - explicit chat
+  - ambiguous
+  - high-confidence structured build
+
+---
+
+### Ticket P1-3: Clarification and Confirmation Gate
+**Outcome**: Build flow cannot start until user confirms; underspecified requests trigger clarification.
+
+**Scope**
+- Pre-execution state transitions and UI contract.
+
+**Implementation Tasks**
+1. Define pre-run states:
+   - `clarification_required`
+   - `waiting_confirmation`
+2. Add server endpoints/actions:
+   - `requestClarification`
+   - `confirmRun`
+   - `cancelRun`
+3. Build draft-edit flow for expensive run requests.
+4. Ensure transitions are idempotent.
+5. Add audit log entries for confirmation actions.
+
+**Deliverables**
+- Confirmation/clarification handlers.
+- State transition table.
+
+**Dependencies**: P1-2
+
+**Acceptance Criteria**
+- Expensive build never starts without explicit user confirmation.
+- User can edit draft before confirmation.
+- User can cancel pending build safely.
+
+**Validation**
+- Integration tests for state transitions and retries.
+
+---
+
+## Phase 2: Execution Path Split
+
+### Ticket P2-1: Synchronous Chat Pipeline with Streaming
+**Outcome**: Chat responses are fast, streaming, and independent of worker queue.
+
+**Scope**
+- Build new synchronous chat path used when router decides chat.
+
+**Implementation Tasks**
+1. Add chat service endpoint/procedure for sync responses.
+2. Implement streaming response transport.
+3. Assemble minimal context for fast first token.
+4. Persist chat user + assistant turns without run artifact coupling.
+5. Add timeout/fallback behavior.
+
+**Deliverables**
+- New chat execution path.
+- Updated UI consumption for streaming.
+
+**Dependencies**: P1-2
+
+**Acceptance Criteria**
+- First token target under 1–2 seconds in typical local/staging scenario.
+- Chat path does not dispatch Inngest job.
+- Streaming emits progressive output.
+
+**Validation**
+- Load test with representative prompts.
+
+---
+
+### Ticket P2-2: Async Build Run Pipeline via Inngest (`Router -> Worker`)
+**Outcome**: Confirmed builds create tracked runs and execute asynchronously.
+
+**Scope**
+- Introduce run creation and worker dispatch by run ID.
+
+**Implementation Tasks**
+1. Create run record on build decision.
+2. Dispatch Inngest event with run ID and canonical input package.
+3. Update worker to:
+   - mark `running` on start
+   - mark `success` or `failed` on completion
+4. Prevent duplicate dispatch for same confirmed run.
+5. Keep chat thread responsive while run executes.
+
+**Deliverables**
+- Run dispatch service.
+- Worker state update hooks.
+
+**Dependencies**: P1-3, P2-1
+
+**Acceptance Criteria**
+- Build path is always async.
+- Run states are persisted and queryable.
+- Duplicate run starts are blocked.
+
+**Validation**
+- Integration test for full queued->running->success/failed transitions.
+
+---
+
+### Ticket P2-3: Failure Summary, Retry, and Cancellation Semantics
+**Outcome**: Operationally safe run lifecycle with recovery paths.
+
+**Scope**
+- Add standardized failure payload and retry/cancel behavior.
+
+**Implementation Tasks**
+1. Define failure taxonomy (tool error, timeout, infra, validation).
+2. Persist user-readable error summary on failed runs.
+3. Implement `retryRun` action:
+   - creates new run
+   - links lineage to prior run
+4. Implement cancellation rules for queued/running runs.
+5. Update UI contract for retry button and state-specific actions.
+
+**Deliverables**
+- Retry/cancel endpoints.
+- Failure summary schema.
+
+**Dependencies**: P2-2
+
+**Acceptance Criteria**
+- Failed runs always expose concise error summary.
+- Retry creates new run with lineage.
+- Cancelled run is terminal and visible in status UI.
+
+**Validation**
+- End-to-end tests for fail->retry and queued->cancel.
+
+---
+
+## Phase 3: Data Model and Artifact Separation
+
+### Ticket P3-1: Schema Migration for `Message`, `Run/Task`, `Artifact`, `ArtifactVersion`, `ArtifactFile`
+**Outcome**: Scalable persistence model where chat is separate from build outputs.
+
+**Scope**
+- In-place schema migration with minimal backward-compat obligations.
+
+**Implementation Tasks**
+1. Add `Run/Task` model and status enums.
+2. Add artifact models:
+   - artifact/project container
+   - immutable versions
+   - file tree/blobs
+3. Link messages to runs by reference only.
+4. Add indexes for query patterns:
+   - thread runs
+   - run status
+   - latest artifact version
+5. Create migration scripts and update Prisma client.
+
+**Deliverables**
+- Prisma schema update.
+- Migration files.
+- Data access layer updates.
+
+**Dependencies**: P2-2
+
+**Acceptance Criteria**
+- Chat message storage no longer acts as output source of truth.
+- Run lifecycle data persists independently.
+- Artifact versions are addressable by run.
+
+**Validation**
+- Migration dry run + rollback plan documented.
+
+---
+
+### Ticket P3-2: Artifact Write Path and Immutable Version Creation
+**Outcome**: Every successful build produces a stable artifact version.
+
+**Scope**
+- Refactor worker persistence from message-attached code blobs to artifact version records.
+
+**Implementation Tasks**
+1. On successful run:
+   - create artifact version
+   - write file tree/blobs
+   - persist metadata (runId, timestamp)
+2. On failure:
+   - do not mutate latest successful version.
+3. Ensure message contains reference/summary, not canonical file payload.
+4. Add retrieval methods for latest and historical versions.
+
+**Deliverables**
+- Worker persistence refactor.
+- Artifact retrieval APIs.
+
+**Dependencies**: P3-1
+
+**Acceptance Criteria**
+- Successful build creates one immutable version.
+- Historical versions remain unchanged.
+- UI can fetch latest version independently from chat history.
+
+**Validation**
+- Tests for version immutability and retrieval correctness.
+
+---
+
+### Ticket P3-3: Hybrid UX Routing (Thread-First, Workspace-When-Needed)
+**Outcome**: Chat remains default UX while larger build work can transition to workspace context.
+
+**Scope**
+- UX behavior changes using existing project UI surfaces.
+
+**Implementation Tasks**
+1. Keep thread as default view.
+2. Add workspace activation rules for substantial builds.
+3. Wire status carousel to run states.
+4. Add deep links from chat assistant response to artifact version/workspace.
+5. Preserve manual user control of fragment/artifact selection.
+
+**Deliverables**
+- UI state rules.
+- Updated message and loading components.
+
+**Dependencies**: P2-2, P3-2
+
+**Acceptance Criteria**
+- User can complete chat-only flows without workspace interruption.
+- Build flow exposes progress and artifact access clearly.
+- Workspace opens only when relevant.
+
+**Validation**
+- UX walkthrough scenarios with acceptance scripts.
+
+---
+
+## Phase 4: Memory and Context Compression
+
+### Ticket P4-1: Thread-Level Memory Assembly (Phase 1 scope)
+**Outcome**: Stable context quality with controlled token and latency usage.
+
+**Scope**
+- Implement memory assembler using thread-level components only.
+
+**Implementation Tasks**
+1. Build context pack structure:
+   - recent 10–20 messages
+   - conversation summary
+   - active artifact summary
+   - selected working files
+2. Add summarization refresh rules (event-driven or periodic).
+3. Ensure context assembly is non-blocking for first token.
+4. Add guards for oversized contexts.
+
+**Deliverables**
+- Memory service module.
+- Context assembly contract used by chat/build prep.
+
+**Dependencies**: P2-1, P3-2
+
+**Acceptance Criteria**
+- Thread-level memory fully functional.
+- Context remains under configured budget limits.
+- No project/user-level global memory introduced in Phase 1.
+
+**Validation**
+- Token budget and latency profile test.
+
+---
+
+### Ticket P4-2: Build Context Packaging for Worker Efficiency
+**Outcome**: Tool runs get only necessary context, reducing cost and failures.
+
+**Scope**
+- Build prep package used for confirmed runs.
+
+**Implementation Tasks**
+1. Define build package schema (requirements, delta intent, working set).
+2. Include clarification answers and final confirmed draft.
+3. Exclude irrelevant thread history by default.
+4. Add package validation before dispatch.
+
+**Deliverables**
+- Build context packager.
+- Validation and rejection reason handling.
+
+**Dependencies**: P1-3, P4-1
+
+**Acceptance Criteria**
+- Worker inputs are concise and deterministic.
+- Confirmed edits are always reflected in run payload.
+- Tool token usage is lower than full-history baseline.
+
+**Validation**
+- Compare payload size and success rate vs baseline.
+
+---
+
+## Phase 5: Observability, Cost Controls, and Rollout
+
+### Ticket P5-1: Routing and Run Observability Stack
+**Outcome**: Full visibility into routing quality, reliability, and latency.
+
+**Scope**
+- Add event logs, metrics, and dashboards.
+
+**Implementation Tasks**
+1. Log routing decisions:
+   - route chosen
+   - reason
+   - confidence
+   - source
+   - confirm-required flag
+2. Log run lifecycle events and durations.
+3. Track success/failure rates by error category.
+4. Add dashboards and threshold alerts.
+
+**Deliverables**
+- Structured logging fields.
+- Dashboard definitions.
+- Alert rules.
+
+**Dependencies**: P1-2, P2-2
+
+**Acceptance Criteria**
+- Required observability dimensions from discovery are live.
+- Team can diagnose false positives and latency spikes quickly.
+
+**Validation**
+- Simulated event replay confirms dashboard accuracy.
+
+---
+
+### Ticket P5-2: Split Budget Controls (Chat Generous, Build Strict)
+**Outcome**: Cost policy enforced by system controls.
+
+**Scope**
+- Separate quota and policy for chat and build paths.
+
+**Implementation Tasks**
+1. Add policy model for separate budgets.
+2. Enforce budget checks at router and run confirmation stages.
+3. Provide user-facing budget feedback messages.
+4. Ensure budget exhaustion on build does not disable baseline chat utility.
+
+**Deliverables**
+- Budget policy configs.
+- Budget enforcement middleware.
+
+**Dependencies**: P2-1, P2-2
+
+**Acceptance Criteria**
+- Chat remains available under stricter tool limits.
+- Build runs are constrained according to policy.
+- Budget denial responses are clear and actionable.
+
+**Validation**
+- Budget simulation test matrix.
+
+---
+
+### Ticket P5-3: Gradual Rollout with Feature Flags and Kill Switches
+**Outcome**: Safe adoption with rollback options.
+
+**Scope**
+- Controlled release across router, sync chat path, runs, artifact storage.
+
+**Implementation Tasks**
+1. Add feature flags for each major subsystem.
+2. Support parallel old/new paths during validation window.
+3. Define kill switch behavior for:
+   - router mode
+   - build dispatch
+   - new artifact write path
+4. Create go/no-go checklist tied to metrics.
+
+**Deliverables**
+- Flag rollout plan.
+- Rollback runbook.
+
+**Dependencies**: all prior phases
+
+**Acceptance Criteria**
+- Each subsystem can be independently toggled.
+- Rollback does not require schema rollback.
+- Parallel execution supported until confidence threshold met.
+
+**Validation**
+- Staging canary rollout and rollback drill.
+
+---
+
+## 5. Sub-Agent Delegation Guide
+
+### Recommended Ticket Order (Critical Path)
+1. P0-1
+2. P0-2
+3. P1-1
+4. P1-2
+5. P1-3
+6. P2-1
+7. P2-2
+8. P3-1
+9. P3-2
+10. P2-3
+11. P3-3
+12. P4-1
+13. P4-2
+14. P5-1
+15. P5-2
+16. P5-3
+
+### Safe Parallelization Opportunities
+- P2-1 and P3-1 can overlap after P1-3 if write scopes are separated.
+- P4-1 can begin once P2-1 has a stable context API.
+- P5-1 logging scaffolding can begin early but finalize after router/run state contracts stabilize.
+
+### Per-Ticket Required Output From Sub-Agent
+- Summary of what changed.
+- Exact files touched.
+- Migration impact (if any).
+- Tests added/updated.
+- Known gaps or follow-up tasks.
+- Evidence for acceptance criteria pass/fail.
+
+## 6. Definition of Done (Global)
+- All required product constraints are implemented and validated.
+- No expensive workflow auto-runs without user confirmation.
+- Chat-first behavior is default and responsive.
+- Tool runs are tracked with lifecycle states and failure/retry UX.
+- Artifacts are canonical in dedicated storage with immutable versioning.
+- Observability and budget controls are active.
+- Rollout is flaggable and reversible.
+


### PR DESCRIPTION
## Summary

- Adds `tasks/p0-inngest-audit.md`: full audit baseline for issue #20
- Both `inngest.send` callsites documented (projects.create + messages.create)
- All 12 worker steps mapped with durability, DB ops, and external calls
- 7-row DB side-effect table with rollback coverage
- 16-row keep/change matrix (Keep / Adapt / Replace) with rationale
- Mermaid sequence diagram: current flow
- Mermaid sequence diagram: target router-worker flow
- 9-item gap/risk register (P0/P1/P2 severity)
- Updates `tasks/phase1-delivery-master-plan.md` P0-1 status to ✅ Done
- Fixes `.gitignore` to allow `tasks/*.md` to be tracked

## Test plan

- [ ] Manual architecture review: verify every `inngest.send` callsite appears in trigger inventory
- [ ] Verify all DB writes in `functions.ts` appear in side-effect table
- [ ] Review keep/change matrix rationale against issue #19 target architecture
- [ ] Confirm sequence diagrams render correctly (GitHub Mermaid preview)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added P0 audit document for the Inngest-triggered build system, documenting trigger flows, database writes, worker steps, and identified risk areas.
* Added Phase 1 delivery master plan outlining the transition to a chat-first assistant with streaming chat, asynchronous build execution, enhanced observability, and improved failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->